### PR TITLE
Add 'void' as a type

### DIFF
--- a/syntax/php.vim
+++ b/syntax/php.vim
@@ -836,7 +836,7 @@ syn keyword phpStatement  return break continue exit goto  contained
 syn keyword phpKeyword  var const contained
 
 " Type
-syn keyword phpType bool[ean] int[eger] real double float string array object NULL  contained
+syn keyword phpType bool[ean] int[eger] real double float string array object NULL void  contained
 
 " Structure
 syn keyword phpStructure  namespace extends implements instanceof parent self contained


### PR DESCRIPTION
In PHP 7.1 'void' has been added as a return type see: https://wiki.php.net/rfc/void_return_type